### PR TITLE
Support batched messages in p2pMessageCode

### DIFF
--- a/whisperv6/whisper.go
+++ b/whisperv6/whisper.go
@@ -429,7 +429,13 @@ func (whisper *Whisper) SendP2PMessage(peerID []byte, envelopes ...*Envelope) er
 }
 
 // SendP2PDirect sends a peer-to-peer message to a specific peer.
+// If only a single envelope is given, data is sent as a single object
+// rather than a slice. This is important to keep this method backward compatible
+// as it used to send only single envelopes.
 func (whisper *Whisper) SendP2PDirect(peer *Peer, envelopes ...*Envelope) error {
+	if len(envelopes) == 1 {
+		return p2p.Send(peer.ws, p2pMessageCode, envelopes[0])
+	}
 	return p2p.Send(peer.ws, p2pMessageCode, envelopes)
 }
 

--- a/whisperv6/whisper.go
+++ b/whisperv6/whisper.go
@@ -863,7 +863,7 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 					continue
 				} else {
 					// @TODO(adam): figure out if this is needed. io.TeeReader docs say
-					// does not copy data to writer if it was not read.
+					// it does not copy data to writer if it was not read.
 					// It might happen that packet.Decode() won't read all data
 					// and exit earlier, hence, we need to make sure all data is read.
 					// To avoid it, it should be possible to write a custom struct that

--- a/whisperv6/whisper_test.go
+++ b/whisperv6/whisper_test.go
@@ -922,9 +922,7 @@ func TestSendP2PDirect(t *testing.T) {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
 
-	// check sent envelopes
-	var envelopes []*Envelope
-
+	// verify sending a single envelope
 	err = w.SendP2PDirect(peerW, env)
 	if err != nil {
 		t.Fatalf("failed to send envelope with seed %d: %s.", seed, err)
@@ -932,14 +930,14 @@ func TestSendP2PDirect(t *testing.T) {
 	if len(rwStub.messages) != 1 {
 		t.Fatalf("invalid number of messages sent to peer: %d, expected 1", len(rwStub.messages))
 	}
-	if err := rwStub.messages[0].Decode(&envelopes); err != nil {
+	var envelope Envelope
+	if err := rwStub.messages[0].Decode(&envelope); err != nil {
 		t.Fatalf("failed to decode envelopes: %s", err)
 	}
-	if len(envelopes) != 1 {
-		t.Fatalf("invalid number of envelopes in a message: %d, expected 1", len(envelopes))
+	if envelope.Hash() != env.Hash() {
+		t.Fatalf("invalid envelope %d, expected %d", envelope.Hash(), env.Hash())
 	}
 	rwStub.messages = nil
-	envelopes = nil
 
 	// send a batch of envelopes
 	err = w.SendP2PDirect(peerW, env, env, env)
@@ -949,6 +947,7 @@ func TestSendP2PDirect(t *testing.T) {
 	if len(rwStub.messages) != 1 {
 		t.Fatalf("invalid number of messages sent to peer: %d, expected 1", len(rwStub.messages))
 	}
+	var envelopes []*Envelope
 	if err := rwStub.messages[0].Decode(&envelopes); err != nil {
 		t.Fatalf("failed to decode envelopes: %s", err)
 	}

--- a/whisperv6/whisper_test.go
+++ b/whisperv6/whisper_test.go
@@ -987,7 +987,7 @@ func TestHandleP2PMessageCode(t *testing.T) {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
 
-	// send a single envelope
+	// read a single envelope
 	rwStub := &rwP2PMessagesStub{}
 	rwStub.payload = []interface{}{env}
 
@@ -1002,13 +1002,18 @@ func TestHandleP2PMessageCode(t *testing.T) {
 		t.Fatalf("received envelope %s while expected %s", e.Hash, env.Hash())
 	}
 
-	// send a batch of envelopes
+	// read a batch of envelopes
 	rwStub = &rwP2PMessagesStub{}
 	rwStub.payload = []interface{}{[]*Envelope{env, env, env}}
 
 	err = w.runMessageLoop(peer, rwStub)
 	if err != nil && err != errRWStub {
 		t.Fatalf("failed run message loop: %s", err)
+	}
+	for i := 0; i < 3; i++ {
+		if e := <-envelopeEvents; e.Hash != env.Hash() {
+			t.Fatalf("received envelope %s while expected %s", e.Hash, env.Hash())
+		}
 	}
 }
 


### PR DESCRIPTION
All `p2pMessageCode` envelopes are sent one-by-one. They can be easily batched to reduce the traffic and number of individual packets.