### PR TITLE
Extend mail response with a peer and refactor tests

### DIFF
--- a/whisperv6/whisper.go
+++ b/whisperv6/whisper.go
@@ -971,7 +971,7 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 					return errors.New("invalid request response message")
 				}
 
-				event, err := CreateMailServerEvent(payload)
+				event, err := CreateMailServerEvent(p.peer.ID(), payload)
 
 				if err != nil {
 					log.Warn("error while parsing request complete code, peer will be disconnected", "peer", p.peer.ID(), "err", err)


### PR DESCRIPTION
Response from a mail server that request was completed is extended with a peer id. Additionally i made some tests to use `require` module.