### PR TITLE
Add SendRawP2PDirect

### DIFF
--- a/whisperv6/doc.go
+++ b/whisperv6/doc.go
@@ -142,6 +142,15 @@ type SyncResponse struct {
 	Error     string
 }
 
+// RawSyncResponse is a struct representing a response sent to the peer
+// asking for syncing archived envelopes.
+type RawSyncResponse struct {
+	Envelopes []rlp.RawValue
+	Cursor    []byte
+	Final     bool // if true it means all envelopes were processed
+	Error     string
+}
+
 // MessagesResponse sent as a response after processing batch of envelopes.
 type MessagesResponse struct {
 	// Hash is a hash of all envelopes sent in the single batch.

--- a/whisperv6/whisper.go
+++ b/whisperv6/whisper.go
@@ -493,6 +493,11 @@ func (whisper *Whisper) SendSyncResponse(p *Peer, data SyncResponse) error {
 	return p2p.Send(p.ws, p2pSyncResponseCode, data)
 }
 
+// SendRawSyncResponse sends a response to a Mail Server with a slice of envelopes.
+func (whisper *Whisper) SendRawSyncResponse(p *Peer, data RawSyncResponse) error {
+	return p2p.Send(p.ws, p2pSyncResponseCode, data)
+}
+
 // SendP2PMessage sends a peer-to-peer message to a specific peer.
 func (whisper *Whisper) SendP2PMessage(peerID []byte, envelopes ...*Envelope) error {
 	p, err := whisper.getPeer(peerID)
@@ -1073,12 +1078,7 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 
 				log.Info("received sync response", "count", len(resp.Envelopes), "final", resp.Final, "err", resp.Error, "cursor", resp.Cursor)
 
-				for _, rawEnvelope := range resp.Envelopes {
-					var envelope *Envelope
-					if err := rlp.DecodeBytes(rawEnvelope, &envelope); err != nil {
-						return errors.New("invalid envelopes")
-					}
-
+				for _, envelope := range resp.Envelopes {
 					whisper.mailServer.Archive(envelope)
 				}
 


### PR DESCRIPTION
Adds a function to send RawValue envelopes. This is needed as a
performance optimization, as currently most of the processing time is
spent decoding envelopes and coding them back when sending them.
This will allow us to skip this unnecessary step.